### PR TITLE
Fix example: wrong getTimeout handler name

### DIFF
--- a/examples/processes/intermediateTimerEvent.js
+++ b/examples/processes/intermediateTimerEvent.js
@@ -1,6 +1,6 @@
 /*global module exports console */
 
-exports.MyTimeout$getTimeout = function(data, done) {
+exports.Intermediate_Catch_Timer_Event$getTimeout = function(data, done) {
     // called when arriving on "Intermediate Catch Timer Event"
     // should return wait time in ms.
     return 10000;


### PR DESCRIPTION
A small example fix in: https://github.com/e2ebridge/bpmn/blob/master/examples/processes/intermediateTimerEvent.js#L3
The $getTimeout handler name ( MyTimeout ) doesn't correspond with the intermediateCatchEvent element name ( Intermediate_Catch_Timer_Event ):
https://github.com/e2ebridge/bpmn/blob/master/examples/processes/intermediateTimerEvent.bpmn#L11